### PR TITLE
nand_group_dump: Fix build on clang 16

### DIFF
--- a/examples/klog_server/source/main.c
+++ b/examples/klog_server/source/main.c
@@ -14,7 +14,7 @@
 #define OFFSET_FORK_FROM_READ 0x1DE0
 #else
 #define OFFSET_FORK_FROM_READ 0x0
-#warning Klog server does not support this firmware, must be updated to be able to find fork().
+#pragma GCC error "Klog server does not support this firmware, must be updated to be able to find fork()."
 #endif
 
 // Ran in child process
@@ -22,7 +22,7 @@ void run_kernel_log_server(int port)
 {
 	// Establish a server
 	int client = 0;
-	int s;
+	int s = 0;
 
 	s = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -92,8 +92,7 @@ extern void *fptr__read;
 
 int payload_main(struct payload_args *args)
 {
-	int mainPID;
-	uint64_t temp_addr;
+	int mainPID = 0;
 
 	// Fork must be resolved manually, dlsym refuses to resolve it
 	void (*fptr_fork)() = (void (*)())(fptr__read + OFFSET_FORK_FROM_READ);

--- a/examples/nand_group_dump/source/main.c
+++ b/examples/nand_group_dump/source/main.c
@@ -29,40 +29,36 @@ struct ioctl_readnandgroup_args
     uint64_t size;
 };
 
-void sock_print(int sock, char *str)
+void sock_print(const int sock, const char *str)
 {
-	size_t size;
-
 #if ENABLE_LOGS
+	size_t size = 0;
 	size = strlen(str);
+	if ( !size || !sock )
+		return;
 	_write(sock, str, size);
 #endif
 }
 
 int payload_main(struct payload_args *args)
 {
-    int ret;
-    int sock;
-    int out_fds[3];
-    int a53_fd;
-    int pupupdate_fd;
-    int zero;
-    int written_bytes;
-    char printbuf[128];
-    struct sockaddr_in addr;
-    struct OrbisKernelSwVersion version;
-    void *out_data;
-    uint64_t nand_size;
-    uint64_t kdata_base;
-    pid_t pid;
-
-    zero         = 0;
-    a53_fd       = -1;
-    pupupdate_fd = -1;
-    out_data     = NULL;
-    kdata_base   = args->kdata_base_addr;
+    int ret = 0;
+    int sock = 0;
+    int out_fds[3] = {0};
+    int a53_fd = -1;
+    int pupupdate_fd = -1;
+    int zero = 0;
+    int written_bytes = 0;
+    char printbuf[128] = {0};
+    struct OrbisKernelSwVersion version = {};
+    void *out_data = NULL;
+    uint64_t nand_size = 0;
+    uint64_t kdata_base = 0;
+    pid_t pid = 0;
+    kdata_base = args->kdata_base_addr;
 
 #if ENABLE_LOGS
+    struct sockaddr_in addr = {};
     sock = socket(AF_INET, SOCK_STREAM, 0);
     if (sock < 0) {
         return -1;
@@ -248,11 +244,11 @@ int payload_main(struct payload_args *args)
 
     // Max 3 NAND groups
     for (int i = 0; i < 3; i++) {
-        memset(out_data, 0, 0x4000000);
+        (void)memset(out_data, 0, 0x4000000);
 
         struct ioctl_readnandgroup_args ioc_args = {};
         ioc_args.group_id = i;
-        ioc_args.p_out = out_data;
+        ioc_args.p_out = (uint64_t)out_data;
 
         // NAND groups have different sizes:
         // group 0 is 0x4000000

--- a/ps5/libkernel.h
+++ b/ps5/libkernel.h
@@ -106,7 +106,7 @@ _Fn_(uint64_t   , _getdirentries,                       void);
 _Fn_(uint64_t   , _getpeername,                         void);
 _Fn_(uint64_t   , _getsockname,                         void);
 _Fn_(uint64_t   , _getsockopt,                          void);
-_Fn_(uint64_t   , _ioctl,                               int fd, unsigned long req, unsigned long data);
+_Fn_(uint64_t   , _ioctl,                               int fd, unsigned long req, void *data);
 _Fn_(uint64_t   , _is_signal_return,                    void);
 _Fn_(uint64_t   , _listen,                              void);
 _Fn_(uint64_t   , _openat,                              void);


### PR DESCRIPTION
```
 FAILED: examples/nand_group_dump/CMakeFiles/nand_group_dumper.dir/source/main.c.o 
/opt/hostedtoolcache/llvm-16.0/bin/clang  -isystem /home/runner/work/PS5SDK/PS5SDK -isystem /home/runner/work/PS5SDK/PS5SDK/include --target=x86_64-freebsd-pc-elf -O0 -DPPR -DPS5 -DPS5_FW_VERSION=0x403  -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200112 -D__BSD_VISIBLE=1 -D__XSI_VISIBLE=500 -fno-builtin -nostdlib -Wall -m64 -fomit-frame-pointer -fPIC -fPIE -pie -Wl,-z,norelro -std=gnu11 -MD -MT examples/nand_group_dump/CMakeFiles/nand_group_dumper.dir/source/main.c.o -MF examples/nand_group_dump/CMakeFiles/nand_group_dumper.dir/source/main.c.o.d -o examples/nand_group_dump/CMakeFiles/nand_group_dumper.dir/source/main.c.o -c /home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c
clang-16: warning: -Wl,-z,norelro: 'linker' input unused [-Wunused-command-line-argument]
clang-16: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
/home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c:34:9: warning: unused variable 'size' [-Wunused-variable]
        size_t size;
               ^
/home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c:221:57: error: incompatible pointer to integer conversion passing 'int *' to parameter of type 'unsigned long' [-Wint-conversion]
    ret = _ioctl(a53_fd, NAND_A53IO_DISABLE_CONTROLLER, &zero);
                                                        ^~~~~
/home/runner/work/PS5SDK/PS5SDK/ps5/libkernel.h:109:98: note: passing argument to parameter 'data' here
_Fn_(uint64_t   , _ioctl,                               int fd, unsigned long req, unsigned long data);
                                                                                                 ^
/home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c:226:43: error: incompatible pointer to integer conversion passing 'int *' to parameter of type 'unsigned long' [-Wint-conversion]
    ret = _ioctl(a53_fd, NAND_A53IO_OPEN, &zero);
                                          ^~~~~
/home/runner/work/PS5SDK/PS5SDK/ps5/libkernel.h:109:98: note: passing argument to parameter 'data' here
_Fn_(uint64_t   , _ioctl,                               int fd, unsigned long req, unsigned long data);
                                                                                                 ^
/home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c:251:9: warning: ignoring return value of function declared with pure attribute [-Wunused-value]
        memset(out_data, 0, 0x4000000);
        ^~~~~~ ~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c:255:24: error: incompatible pointer to integer conversion assigning to 'uint64_t' (aka 'unsigned long long') from 'void *' [-Wint-conversion]
        ioc_args.p_out = out_data;
                       ^ ~~~~~~~~
/home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c:272:65: error: incompatible pointer to integer conversion passing 'struct ioctl_readnandgroup_args *' to parameter of type 'unsigned long' [-Wint-conversion]
        ret = _ioctl(pupupdate_fd, PUP_UPDATER_READ_NAND_GROUP, &ioc_args);
                                                                ^~~~~~~~~
/home/runner/work/PS5SDK/PS5SDK/ps5/libkernel.h:109:98: note: passing argument to parameter 'data' here
_Fn_(uint64_t   , _ioctl,                               int fd, unsigned long req, unsigned long data);
                                                                                                 ^
/home/runner/work/PS5SDK/PS5SDK/examples/nand_group_dump/source/main.c:52:24: warning: unused variable 'addr' [-Wunused-variable]
    struct sockaddr_in addr;
                       ^
3 warnings and 4 errors generated.
```