### PR TITLE
Reduce the minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # @author Znullptr
 ###################################################################################################
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.16)
 
 set(basename "example_project")
 project(${basename} C CXX ASM)

--- a/crt/CMakeLists.txt
+++ b/crt/CMakeLists.txt
@@ -3,7 +3,7 @@
 # @author Znullptr
 ###################################################################################################
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.16)
 
 set(basename "ps5sdk_crt")
 project(${basename} C CXX ASM)

--- a/examples/hello_socket/CMakeLists.txt
+++ b/examples/hello_socket/CMakeLists.txt
@@ -4,7 +4,7 @@
 # @author Specter
 ###################################################################################################
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.16)
 
 set(basename "hello_socket")
 project(${basename} C CXX ASM)

--- a/examples/klog_server/CMakeLists.txt
+++ b/examples/klog_server/CMakeLists.txt
@@ -4,7 +4,7 @@
 # @authors Specter
 ###################################################################################################
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.16)
 
 set(basename "klog_server")
 project(${basename} C CXX ASM)

--- a/examples/nand_group_dump/CMakeLists.txt
+++ b/examples/nand_group_dump/CMakeLists.txt
@@ -4,7 +4,7 @@
 # @authors Specter
 ###################################################################################################
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.16)
 
 set(basename "nand_group_dumper")
 project(${basename} C CXX ASM)

--- a/examples/pipe_pirate/CMakeLists.txt
+++ b/examples/pipe_pirate/CMakeLists.txt
@@ -4,7 +4,7 @@
 # @authors ChendoChap, Specter, Znullptr
 ###################################################################################################
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.16)
 
 set(basename "pipe_pirate")
 project(${basename} C CXX ASM)


### PR DESCRIPTION
I tested this on an old PC with ubuntu 20.04, seems to work fine